### PR TITLE
Update sidebar drawing name in real-time

### DIFF
--- a/src/views/Page.tsx
+++ b/src/views/Page.tsx
@@ -44,6 +44,7 @@ export default function Page({ id }: PageProps) {
       setIsSaving(false);
       // Invalidate the pages cache to update the sidebar
       queryClient.invalidateQueries({ queryKey: ["pages"] });
+      queryClient.invalidateQueries({ queryKey: ["folderPages"] });
       // REMOVED: queryClient.invalidateQueries({ queryKey: ["page", id] });
       // This was causing data loss by immediately refetching and overwriting user changes
     },


### PR DESCRIPTION
Invalidate `folderPages` query to ensure the sidebar updates immediately after a drawing name change.